### PR TITLE
Client/CDN caching of gzipped files

### DIFF
--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -136,10 +136,10 @@ exports = module.exports = function staticGzip(dirPath, options){
 			var base = path.basename(filename),
 					dir = path.dirname(filename),
 					gzipName = path.join(dir, base + '.gz');
-
+			
 			if (req.headers['if-modified-since'] &&
 				gzippoCache[gzipName] &&
-				(new Date(gzippoCache[gzipName].mtime)).getTime() >= (new Date(req.headers['if-modified-since'])).getTime()) {
+				(new Date(gzippoCache[gzipName].mtime)).getTime() <= (new Date(req.headers['if-modified-since'])).getTime()) {
 				contentType = contentType + (charset ? '; charset=' + charset : '');
 				res.setHeader('Content-Type', contentType);
 				res.setHeader('Content-Encoding', 'gzip');

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -125,7 +125,6 @@ exports = module.exports = function staticGzip(dirPath, options){
 			return pass(filename);
 		}
 
-		console.log(req.headers);
 		//This is storing in memory for the moment, need to think what the best way to do this.
 		//Check file is not a directory
 		
@@ -141,6 +140,13 @@ exports = module.exports = function staticGzip(dirPath, options){
 			if (req.headers['if-modified-since'] &&
 				gzippoCache[gzipName] &&
 				(new Date(gzippoCache[gzipName].mtime)).getTime() >= (new Date(req.headers['if-modified-since'])).getTime()) {
+				contentType = contentType + (charset ? '; charset=' + charset : '');
+				res.setHeader('Content-Type', contentType);
+				res.setHeader('Content-Encoding', 'gzip');
+				res.setHeader('Vary', 'Accept-Encoding');
+				res.setHeader('Last-Modified', gzippoCache[gzipName].mtime);
+				res.setHeader('Date', (new Date()).toUTCString());
+				res.setHeader('Expires', (new Date((new Date()).getTime()+maxAge)).toUTCString());
 				return res.send(304);
 			}
 					

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -82,13 +82,16 @@ exports = module.exports = function staticGzip(dirPath, options){
 			staticSend(req, res, next, o);
 		}
 		
-		function sendGzipped(data) {
+		function sendGzipped(cacheObj) {
 			contentType = contentType + (charset ? '; charset=' + charset : '');
 			res.setHeader('Content-Type', contentType);
 			res.setHeader('Content-Encoding', 'gzip');
 			res.setHeader('Vary', 'Accept-Encoding');	
-			res.setHeader('Content-Length', data.length);
-			res.end(data, 'binary');
+			res.setHeader('Content-Length', cacheObj.content.length);
+			res.setHeader('Last-Modified', cacheObj.mtime);
+			res.setHeader('Date', (new Date()).toUTCString());
+			res.setHeader('Expires', (new Date((new Date()).getTime()+maxAge)).toUTCString());
+			res.end(cacheObj.content, 'binary');
 		}
 		
 		function gzipAndSend(filename, gzipName, mtime) {
@@ -98,7 +101,7 @@ exports = module.exports = function staticGzip(dirPath, options){
 					'mtime': mtime,
 					'content': gzippedData
 				};
-				sendGzipped(gzippedData);
+				sendGzipped(gzippoCache[gzipName]);
 			});	
 		}
 		
@@ -121,7 +124,8 @@ exports = module.exports = function staticGzip(dirPath, options){
 		if (!~acceptEncoding.indexOf('gzip')) {
 			return pass(filename);
 		}
-		
+
+		console.log(req.headers);
 		//This is storing in memory for the moment, need to think what the best way to do this.
 		//Check file is not a directory
 		
@@ -133,17 +137,23 @@ exports = module.exports = function staticGzip(dirPath, options){
 			var base = path.basename(filename),
 					dir = path.dirname(filename),
 					gzipName = path.join(dir, base + '.gz');
+
+			if (req.headers['if-modified-since'] &&
+				gzippoCache[gzipName] &&
+				(new Date(gzippoCache[gzipName].mtime)).getTime() >= (new Date(req.headers['if-modified-since'])).getTime()) {
+				return res.send(304);
+			}
 					
 			//check for pre-compressed file 
 			//TODO: Look into placing into a loop and using dot notation for speed improvements. 
 			if (typeof gzippoCache[gzipName] === 'undefined') {
-				gzipAndSend(filename, gzipName, stat.mtime);
+				gzipAndSend(filename, gzipName, (new Date(stat.mtime)).toUTCString());
 			} else {
         if ((gzippoCache[gzipName].mtime < stat.mtime) || 
           ((gzippoCache[gzipName].ctime + maxAge) < Date.now())) {
-					gzipAndSend(filename, gzipName, stat.mtime);
+					gzipAndSend(filename, gzipName, (new Date(stat.mtime)).toUTCString());
 				} else {
-					sendGzipped(gzippoCache[gzipName].content);
+					sendGzipped(gzippoCache[gzipName]);
 				}
 			}
 		});

--- a/test/staticGzipTest.js
+++ b/test/staticGzipTest.js
@@ -111,22 +111,27 @@ module.exports = {
 		);
 	},
 	'requesting gzipped utf-8 file second time caches': function() {
-		assert.response(app, { url: '/utf8.txt', headers: { 'Accept-Encoding':"gzip" } }, function(res) {
-			console.log(res);
-			assert.response(app,
-				{
-					url: '/utf8.txt',
-					headers: {
-						'Accept-Encoding':"gzip",
-						'If-Modified-Since': 'Mon, 28 Dec 2020 01:00:00 GMT'
-					}
-				},
-				function(res) {
-					console.log(res);
-					res.statusCode.should.equal(304);
+		assert.response(app,
+			{
+				url: '/utf8.txt',
+				headers: {
+					'Accept-Encoding':"gzip",
 				}
-			);
-
-		});
+			},
+			function(res) {
+				assert.response(app,
+					{
+						url: '/utf8.txt',
+						headers: {
+							'Accept-Encoding':"gzip",
+							'If-Modified-Since': 'Mon, 28 Dec 2020 01:00:00 GMT'
+						}
+					},
+					function(res) {
+						res.statusCode.should.equal(304);
+					}
+				);
+			}
+		);
 	}
 };

--- a/test/staticGzipTest.js
+++ b/test/staticGzipTest.js
@@ -109,5 +109,24 @@ module.exports = {
 				res.headers.should.have.property('content-encoding', 'gzip');
 			}
 		);
+	},
+	'requesting gzipped utf-8 file second time caches': function() {
+		assert.response(app, { url: '/utf8.txt', headers: { 'Accept-Encoding':"gzip" } }, function(res) {
+			console.log(res);
+			assert.response(app,
+				{
+					url: '/utf8.txt',
+					headers: {
+						'Accept-Encoding':"gzip",
+						'If-Modified-Since': 'Mon, 28 Dec 2020 01:00:00 GMT'
+					}
+				},
+				function(res) {
+					console.log(res);
+					res.statusCode.should.equal(304);
+				}
+			);
+
+		});
 	}
 };


### PR DESCRIPTION
We're planning on using gzippo in our start-up, but we needed it to respond to modification checks so we don't negate the gain from compressing the files by requiring them to be downloaded by the client on every request, so I've added two related changes to gzippo:

1) The maxAge value is used to set the expiration date ('Expires') of the file (which also requires the current server's date ['Date'] to be sent so the browser can then re-extract the maxAge value).
2) The mtime value is used to set 'Last-Modified' for the file, which is used by a client with a cached copy to query if a new version exists ('If-Modified-Since'). At this point the server either responds with the new version, or returns '304' stating that the client has the newest revision.

There's also a test for the new code and it passes, and I tried to match your programming style, so hopefully you'll accept these changes. :)
