### PR TITLE
Modular cache store

### DIFF
--- a/lib/memoryStore.js
+++ b/lib/memoryStore.js
@@ -18,9 +18,8 @@ exports = module.exports = (function() {
 		}
 	};
 	this.set = function(pathname, cacheObj, callback) {
-		var oldCache = typeof(cache[pathname]) == "object" ? cache[pathname] : undefined;
 		cache[pathname] = cacheObj;
-		return callback(undefined, oldCache);
+		return callback(undefined);
 	};
 	return this;
 })();

--- a/lib/memoryStore.js
+++ b/lib/memoryStore.js
@@ -1,0 +1,22 @@
+/*!
+ * David Ellis
+ * 
+ * MIT Licensed
+ */
+
+/**
+ * gzipped in-memory cache.
+ */
+
+exports = module.exports = (function() {
+	var cache = {};
+	this.get = function(pathname) {
+		return cache[pathname];
+	};
+	this.set = function(pathname, cacheObj) {
+		var oldCache = typeof(cache[pathname]) == "object" ? cache[pathname] : undefined;
+		cache[pathname] = cacheObj;
+		return oldCache;
+	};
+	return this;
+})();

--- a/lib/memoryStore.js
+++ b/lib/memoryStore.js
@@ -10,13 +10,17 @@
 
 exports = module.exports = (function() {
 	var cache = {};
-	this.get = function(pathname) {
-		return cache[pathname];
+	this.get = function(pathname, callback) {
+		if(cache[pathname]) {
+			return callback(undefined, cache[pathname]);
+		} else {
+			return callback(new Error("File not in cache"), undefined);
+		}
 	};
-	this.set = function(pathname, cacheObj) {
+	this.set = function(pathname, cacheObj, callback) {
 		var oldCache = typeof(cache[pathname]) == "object" ? cache[pathname] : undefined;
 		cache[pathname] = cacheObj;
-		return oldCache;
+		return callback(undefined, oldCache);
 	};
 	return this;
 })();

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -36,10 +36,21 @@ var removeContentHeaders = function(res){
 };
 
 /**
- * gzipped cache.
+ * gzipped in-memory cache.
  */
 
-var gzippoCache = {};
+var gzippoCache = (function() {
+	var cache = {};
+	this.get = function(pathname) {
+		return cache[pathname];
+	};
+	this.set = function(pathname, cacheObj) {
+		var oldCache = typeof(cache[pathname]) == "object" ? cache[pathname] : undefined;
+		cache[pathname] = cacheObj;
+		return oldCache;
+	};
+	return this;
+})();
 
 /**
  * gzip file.
@@ -65,6 +76,7 @@ var gzippo = function(filename, charset, callback) {
  *	-	`clientMaxAge`  client cache-control max-age directive, defaulting to 1 week
  *	-	`matchType` - A regular expression tested against the Content-Type header to determine whether the response 
  *		should be gzipped or not. The default value is `/text|javascript|json/`.
+ *	-	`cacheStore` - An object that implements a simple get/set API for storing/retrieving cached data, defaulting to a built-in in-memory store
  *
  * Examples:
  *
@@ -87,6 +99,7 @@ exports = module.exports = function staticGzip(dirPath, options){
 	var maxAge = options.maxAge || 86400000,
 	contentTypeMatch = options.contentTypeMatch || /text|javascript|json/,
 	clientMaxAge = options.clientMaxAge || 604800000;
+	cacheStore = options.cacheStore || gzippoCache;
 	
 	if (!dirPath) throw new Error('You need to provide the directory to your static content.');
 	if (!contentTypeMatch.test) throw new Error('contentTypeMatch: must be a regular expression.');
@@ -119,12 +132,13 @@ exports = module.exports = function staticGzip(dirPath, options){
 		
 		function gzipAndSend(filename, gzipName, mtime) {
 			gzippo(filename, charset, function(gzippedData) {
-				gzippoCache[gzipName] = {
+				var cacheObj = {
 					'ctime': Date.now(),
 					'mtime': mtime,
 					'content': gzippedData
 				};
-				sendGzipped(gzippoCache[gzipName]);
+				cacheStore.set(gzipName, cacheObj);
+				sendGzipped(cacheObj);
 			});	
 		}
 		
@@ -159,26 +173,26 @@ exports = module.exports = function staticGzip(dirPath, options){
 
 			var base = path.basename(filename),
 					dir = path.dirname(filename),
-					gzipName = path.join(dir, base + '.gz');
-			
+					gzipName = path.join(dir, base + '.gz'),
+					cacheObj = cacheStore.get(gzipName);
 			if (req.headers['if-modified-since'] &&
-				gzippoCache[gzipName] &&
-				+gzippoCache[gzipName].mtime <= new Date(req.headers['if-modified-since']).getTime()) {
-				setHeaders(gzippoCache[gzipName]);
+				cacheObj &&
+				+cacheObj.mtime <= new Date(req.headers['if-modified-since']).getTime()) {
+				setHeaders(cacheObj);
 				removeContentHeaders(res);
 				res.statusCode = 304;
 				return res.end();
 			}
 					
 			//TODO: check for pre-compressed file 
-			if (typeof gzippoCache[gzipName] === 'undefined') {
+			if (typeof cacheObj === 'undefined') {
 				gzipAndSend(filename, gzipName, stat.mtime);
 			} else {
-				if ((gzippoCache[gzipName].mtime < stat.mtime) || 
-				((gzippoCache[gzipName].ctime + maxAge) < Date.now())) {
+				if ((cacheObj.mtime < stat.mtime) || 
+				((cacheObj.ctime + maxAge) < Date.now())) {
 					gzipAndSend(filename, gzipName, stat.mtime);
 				} else {
-					sendGzipped(gzippoCache[gzipName]);
+					sendGzipped(cacheObj);
 				}
 			}
 		});

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -98,7 +98,7 @@ exports = module.exports = function staticGzip(dirPath, options){
 	options = options || {};
 	var maxAge = options.maxAge || 86400000,
 	contentTypeMatch = options.contentTypeMatch || /text|javascript|json/,
-	clientMaxAge = options.clientMaxAge || 604800000;
+	clientMaxAge = options.clientMaxAge || 604800000,
 	cacheStore = options.cacheStore || gzippoCache;
 	
 	if (!dirPath) throw new Error('You need to provide the directory to your static content.');

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -121,7 +121,7 @@ exports = module.exports = function staticGzip(dirPath, options){
 					'mtime': mtime,
 					'content': gzippedData
 				};
-				cacheStore.set(gzipName, cacheObj);
+				cacheStore.set(gzipName, cacheObj, function(err, oldObj) { });
 				sendGzipped(cacheObj);
 			});	
 		}
@@ -157,28 +157,30 @@ exports = module.exports = function staticGzip(dirPath, options){
 
 			var base = path.basename(filename),
 					dir = path.dirname(filename),
-					gzipName = path.join(dir, base + '.gz'),
-					cacheObj = cacheStore.get(gzipName);
-			if (req.headers['if-modified-since'] &&
-				cacheObj &&
-				+cacheObj.mtime <= new Date(req.headers['if-modified-since']).getTime()) {
-				setHeaders(cacheObj);
-				removeContentHeaders(res);
-				res.statusCode = 304;
-				return res.end();
-			}
-					
-			//TODO: check for pre-compressed file 
-			if (typeof cacheObj === 'undefined') {
-				gzipAndSend(filename, gzipName, stat.mtime);
-			} else {
-				if ((cacheObj.mtime < stat.mtime) || 
-				((cacheObj.ctime + maxAge) < Date.now())) {
+					gzipName = path.join(dir, base + '.gz');
+
+			cacheStore.get(gzipName, function(err, cacheObj) {
+				if (req.headers['if-modified-since'] &&
+					cacheObj &&
+					+cacheObj.mtime <= new Date(req.headers['if-modified-since']).getTime()) {
+					setHeaders(cacheObj);
+					removeContentHeaders(res);
+					res.statusCode = 304;
+					return res.end();
+				}
+						
+				//TODO: check for pre-compressed file 
+				if (typeof cacheObj === 'undefined') {
 					gzipAndSend(filename, gzipName, stat.mtime);
 				} else {
-					sendGzipped(cacheObj);
+					if ((cacheObj.mtime < stat.mtime) || 
+					((cacheObj.ctime + maxAge) < Date.now())) {
+						gzipAndSend(filename, gzipName, stat.mtime);
+					} else {
+						sendGzipped(cacheObj);
+					}
 				}
-			}
+			});
 		});
 	};
 };

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -13,6 +13,7 @@ var fs = require('fs'),
 		path = require('path'),
 		mime = require('mime'),
 		compress = require('compress'),
+		gzippoCache = require('./memoryStore'),
 		staticSend;
 try {
 	staticSend = require('connect').static.send;
@@ -34,23 +35,6 @@ var removeContentHeaders = function(res){
 		}
 	});
 };
-
-/**
- * gzipped in-memory cache.
- */
-
-var gzippoCache = (function() {
-	var cache = {};
-	this.get = function(pathname) {
-		return cache[pathname];
-	};
-	this.set = function(pathname, cacheObj) {
-		var oldCache = typeof(cache[pathname]) == "object" ? cache[pathname] : undefined;
-		cache[pathname] = cacheObj;
-		return oldCache;
-	};
-	return this;
-})();
 
 /**
  * gzip file.

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -121,7 +121,7 @@ exports = module.exports = function staticGzip(dirPath, options){
 					'mtime': mtime,
 					'content': gzippedData
 				};
-				cacheStore.set(gzipName, cacheObj, function(err, oldObj) { });
+				cacheStore.set(gzipName, cacheObj, function(err) { });
 				sendGzipped(cacheObj);
 			});	
 		}


### PR DESCRIPTION
Hi again,

I'd like to write a MongoDB cache backend for gzippo, so I needed to make the cache storage modular.

I don't want to force a particular API on you, nor do I want to make the MongoDB backend and then need to rewrite large portions if the API is changed dramatically.

So, here's a first stab at a modular cache store, which I think was on your todo list, anyways? All of the tests still pass and its working on the dev version of our (yet-to-be-launched) site.

The MongoDB cache backend will probably be in a repo named: gzippo-cache-mongodb.

I can also see a file-based caching backend, which could be part of mainline, and is also on your todo list, afaict.

David
