### PR TITLE
Fix matchType references with contentTypeMatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In your express/connect server setup, use as follows:
 
 Options:
 
-- `matchType` - A regular expression tested against the Content-Type header to determine whether the response should be gzipped or not. The default value is `/text|javascript|json/`.
+- `contentTypeMatch` - A regular expression tested against the Content-Type header to determine whether the response should be gzipped or not. The default value is `/text|javascript|json/`.
 - `maxAge` - cache-control max-age directive, defaulting to 1 day
 - `clientMaxAge` - browser cache-control max-age directive, defaulting to 1 week
 

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -63,7 +63,7 @@ var gzippo = function(filename, charset, callback) {
  *
  *	-	`maxAge`  cache-control max-age directive, defaulting to 1 day
  *	-	`clientMaxAge`  client cache-control max-age directive, defaulting to 1 week
- *	-	`matchType` - A regular expression tested against the Content-Type header to determine whether the response 
+ *	-	`contentTypeMatch` - A regular expression tested against the Content-Type header to determine whether the response 
  *		should be gzipped or not. The default value is `/text|javascript|json/`.
  *
  * Examples:


### PR DESCRIPTION
This just fixes the documentation reference to matchType which should be contentTypeMatch.
