### PR TITLE
Pass in gzippo's maxAge when deferring to connect.static.send for non-gzippable content

### DIFF
--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -97,6 +97,7 @@ exports = module.exports = function staticGzip(dirPath, options){
 		function pass(name) {
 			var o = Object.create(options);
 			o.path = name;
+			o.maxAge = maxAge;
 			staticSend(req, res, next, o);
 		}
 		


### PR DESCRIPTION
Currently, files which fail to match contentTypeMatch are served with the underlying connect.static.send which defaults to maxAge=0 (i.e. they are immediately stale). This has the undesirable consequence that any image files served by gZippo are thus never cached by the browser (the browser does reuse the file, but it always queries the server with an If-Modified-Since).

With this change, we use gZippo's maxAge value when 'pass'ing to connect.

This brings up an interesting issue of whether gZippo is intended solely for gzippable content ... or whether it should try to replicate normal 'static' middleware behavior for other content types (e.g. images). It might be interesting to contemplate using the same 'options' format for gZippo as the underlying connect middleware for maximum overlap.
