### PR TITLE
was checking mtime of cache rather than disk, resulting in stale versions

### DIFF
--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -164,7 +164,7 @@ exports = module.exports = function staticGzip(dirPath, options){
 			
 			if (req.headers['if-modified-since'] &&
 				gzippoCache[gzipName] &&
-				+gzippoCache[gzipName].mtime <= new Date(req.headers['if-modified-since']).getTime()) {
+				+stat.mtime <= new Date(req.headers['if-modified-since']).getTime()) {
 				setHeaders(gzippoCache[gzipName]);
 				removeContentHeaders(res);
 				res.statusCode = 304;


### PR DESCRIPTION
was checking mtime of cache rather than disk, resulting in stale versions served
