### PR TITLE
Fixing issue #14

### DIFF
--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -154,7 +154,11 @@ exports = module.exports = function staticGzip(dirPath, options){
 		//Check file is not a directory
 
 		fs.stat(decodeURI(filename), function(err, stat) {
-			if (err || stat.isDirectory()) {
+			if (err) {
+				return pass(filename);
+			}
+
+			if (stat.isDirectory()) {
 				return pass(req.url);
 			}
 

--- a/test/staticGzipTest.js
+++ b/test/staticGzipTest.js
@@ -177,5 +177,15 @@ module.exports = {
 				res.statusCode.should.not.equal(404);
 			}
 		);
+	},
+	'Ensuring req.url isnt passed to staticSend on error': function() {
+		assert.response(app,
+			{
+				url: '/etc/passwd'
+			},
+			function(res) {
+				res.statusCode.should.equal(404);
+			}
+		);
 	}
 };


### PR DESCRIPTION
Only passing req.url to staticSend if it is a directory.

If error, pass the full filename to staticSend.
