### PR TITLE
add directory index file support

### DIFF
--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -161,6 +161,9 @@ exports = module.exports = function staticGzip(dirPath, options){
       return forbidden(res);
     }
 
+		// directory index file support
+		if (filename.substr(-1) === '/') filename += 'index.html';
+
 		contentType = mime.lookup(filename);
 		charset = mime.charsets.lookup(contentType, 'UTF-8');
 		contentType = contentType + (charset ? '; charset=' + charset : '');

--- a/test/fixtures/index_test/index.html
+++ b/test/fixtures/index_test/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+    <head><title>Index Test</title></head>
+    <body>
+        <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+    </body>
+</html>

--- a/test/staticGzipTest.js
+++ b/test/staticGzipTest.js
@@ -147,6 +147,20 @@ module.exports = {
 			}
 		);
 	},
+	'requesting directory returns index.html if found': function() {
+		assert.response(getApp(),
+			{
+				url: '/index_test/',
+				headers: {
+					'Accept-Encoding': "gzip"
+				}
+			},
+			function(res) {
+				res.statusCode.should.equal(200);
+				res.headers.should.have.property('content-length', '366');
+			}
+		);
+	},
 	'ensuring max age is set on resources which are passed to the default static content provider': function() {
 		assert.response(getApp(),
 			{


### PR DESCRIPTION
Copied the logic from connect's static middleware which appends 'index.html', if the final character of the file name is '/'.
