### PR TITLE
Fix #40

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "compress"
   ],
   "engines": {
-    "node": ">= 0.5 < 0.7"
+    "node": ">= 0.5 < 0.9"
   },
   "scripts": {
     "test": "expresso"


### PR DESCRIPTION
`package.json` in the v0.1.6 release requires the node binary to be of version `>= 0.5 < 0.7`. This meant that when running `npm install gzippo`, npm would fall back to v0.0.6, which accepts any node version.

All tests pass on v0.8.0, so I simply went ahead and changed the version requirements.

Hopefully this fixes issue #40.
