### PR TITLE
Fixes 404 when request header Accept-Encoding not set

### DIFF
--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -209,7 +209,6 @@ exports = module.exports = function staticGzip(dirPath, options){
             }
         }
 
-        if (!method) return pass(filename);
 
         fs.stat(filename, function(err, stat) {
 
@@ -221,6 +220,9 @@ exports = module.exports = function staticGzip(dirPath, options){
                 return next();
             }
 
+            // Check if file exists before passing uncompressed to client
+		        if (!method) return pass(filename);
+    
             if (!contentTypeMatch.test(contentType)) {
                 return pass(filename);
             }

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -216,13 +216,13 @@ exports = module.exports = function staticGzip(dirPath, options){
                 return next();
             }
 
+            // Check if file exists before passing uncompressed to client
+		        if (!method) return pass(filename);
+
             if (stat.isDirectory()) {
                 return next();
             }
 
-            // Check if file exists before passing uncompressed to client
-		        if (!method) return pass(filename);
-    
             if (!contentTypeMatch.test(contentType)) {
                 return pass(filename);
             }


### PR DESCRIPTION
When static middleware is enabled, sending a request without
Accept-Encoding set would cause a premature call to pass()
before checking if the requested file exists. This meant that
calls to normal Express routes would be intercepted and result
in 404s.

This pull request addresses the Issue detailed here:
https://github.com/tomgco/gzippo/issues/47
