### PR TITLE
Cache all files, compress only matched

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
   - 0.6
+  - 0.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
   - 0.6
-  - 0.7
+  - 0.8

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,5 @@
+Changes from version 0.1 to 0.2:
+
+`clientMaxAge` now defaults to 0.
+Zlib Deflate support
+Gzippo should now support external stores, gridfs, redis etc...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gzippo [![Build Status](https://secure.travis-ci.org/tomgallacher/gzippo.png)](https://secure.travis-ci.org/tomgallacher/gzippo)
+# gzippo [![Build Status](https://secure.travis-ci.org/tomgco/gzippo.png?branch=master)](https://secure.travis-ci.org/tomgco/gzippo)
 
 gzippo pronounced `g-zippo` is a gzip middleware for Connect / expressjs using node-compress for better performace, in node 0.6 and up will be using the new zlib api.
 

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
 exports.staticGzip = require("./lib/staticGzip.js");
 exports.compress = require("./lib/compress.js");
+exports.Store = require('./lib/store.js');

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-exports.staticGzip = require("./lib/staticGzip.js");
-exports.compress = require("./lib/compress.js");
+exports.staticGzip = require('./lib/staticGzip.js');
+exports.compress = require('./lib/compress.js');
 exports.Store = require('./lib/store.js');

--- a/lib/fileAsset.js
+++ b/lib/fileAsset.js
@@ -1,0 +1,55 @@
+var FileAsset = module.exports = function FileAsset(name, mtime) {
+  this._fileName = name;
+  this._mtime = mtime;
+  this._ctime = +Date.now();
+  this.fileContents = [];
+  this.fileContentsLength = 0;
+  this._maxAge = 86400000;
+};
+
+/**
+ * Prototype.
+ */
+
+FileAsset.prototype = {
+  set maxAge(maxAge) {
+    this._maxAge = maxAge;
+  },
+
+  get maxAge() {
+    return this_.maxAge;
+  },
+
+  get isExpired() {
+    return (this._ctime + this._maxAge) < +Date.now();
+  },
+
+  get name() {
+    return this._fileName;
+  },
+
+  set content(data) {
+    this.fileContents.push(data);
+    this.fileContentsLength += data.length;
+  },
+
+  get content() {
+    var file = Buffer(this.fileContentsLength);
+    var pos = 0;
+    for (var i = 0; i < this.fileContents.length; i++) {
+      var buffer = this.fileContents[i];
+      buffer.copy(file, pos);
+      pos += buffer.length;
+    }
+
+    return file;
+  },
+
+  get data() {
+    return {
+      expires: this._expires,
+      mtime: this._mtime,
+      content: this.content
+    };
+  }
+};

--- a/lib/fileAsset.js
+++ b/lib/fileAsset.js
@@ -17,7 +17,11 @@ FileAsset.prototype = {
   },
 
   get maxAge() {
-    return this_.maxAge;
+    return this._maxAge;
+  },
+
+  get mtime() {
+    return this._mtime;
   },
 
   get isExpired() {
@@ -28,28 +32,28 @@ FileAsset.prototype = {
     return this._fileName;
   },
 
-  set content(data) {
-    this.fileContents.push(data);
-    this.fileContentsLength += data.length;
+  get content() {
+    // var file = Buffer(this.fileContentsLength);
+    // var pos = 0;
+    // for (var i = 0; i < this.fileContents.length; i++) {
+    //   // this.fileContents[i] = this.fileContents[i].toString();
+    //   // buffer.copy(file, pos);
+    //   // pos += buffer.length;
+    // }
+
+    return this.fileContents;
   },
 
-  get content() {
-    var file = Buffer(this.fileContentsLength);
-    var pos = 0;
-    for (var i = 0; i < this.fileContents.length; i++) {
-      var buffer = this.fileContents[i];
-      buffer.copy(file, pos);
-      pos += buffer.length;
-    }
-
-    return file;
+  get length() {
+    return this.fileContentsLength;
   },
 
   get data() {
     return {
       expires: this._expires,
       mtime: this._mtime,
-      content: this.content
+      content: this.content,
+      length: this.fileContentsLength
     };
   }
 };

--- a/lib/fileAsset.js
+++ b/lib/fileAsset.js
@@ -1,10 +1,12 @@
-var FileAsset = module.exports = function FileAsset(name, mtime) {
+var FileAsset = module.exports = function FileAsset(name, options) {
+  options = options || {};
+  this._maxAge = options.maxAge || 86400000;
+  this._mtime = options.mtime || new Date();
+
   this._fileName = name;
-  this._mtime = mtime;
   this._ctime = +Date.now();
   this.fileContents = [];
   this.fileContentsLength = 0;
-  this._maxAge = 86400000;
 };
 
 /**

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -1,0 +1,103 @@
+
+/*!
+ * gzippo - MemoryStore
+ *
+ * MIT Licensed
+ */
+
+var Store = require('./store'),
+    util = require('util');
+
+/**
+ * new `MemoryStore`.
+ *
+ * @api public
+ */
+
+var MemoryStore = module.exports = function MemoryStore() {
+  Store.call(this);
+  this.assets = {};
+};
+
+util.inherits(MemoryStore, Store);
+
+/**
+ * Attempt to fetch an asset by its filename - `file`.
+ *
+ * @param {String} fileName
+ * @param {Function} cb
+ * @api public
+ */
+
+MemoryStore.prototype.get = function(fileName, cb) {
+  var that = this;
+  process.nextTick(function(){
+    var expires,
+        asset = that.assets[fileName];
+    if (asset) {
+      // expires = (typeof asset.expires === 'string') ?
+      //   +Date.parse(asset.expires) :
+      //   asset.expires;
+      // if (!expires || +Date.now() < expires) {
+        cb(null, asset);
+      // } else {
+      //   that.purgeFile(file, cb);
+      // }
+    } else {
+      cb();
+    }
+  });
+};
+
+/**
+ *
+ * @param {FileAsset} asset
+ * @param {Function} cb
+ * @api public
+ */
+
+MemoryStore.prototype.set = function(asset, cb) {
+  var that = this;
+  process.nextTick(function() {
+    that.assets[asset.name] = asset.data;
+    if(cb instanceof Function) cb();
+  });
+};
+
+/**
+ * purge the cache
+ *
+ * @param {Function} cb
+ * @api public
+ */
+
+MemoryStore.prototype.purge = function(cb){
+  this.assets = {};
+  if(cb instanceof Function) cb();
+};
+
+/**
+ * purge the an item from thecache
+ *
+ * @param {FileAsset} asset
+ * @param {Function} cb
+ * @api public
+ */
+
+MemoryStore.prototype.purgeFile = function(asset, cb){
+  process.nextTick(function() {
+    delete this.assets[asset.name];
+    if(cb instanceof Function) cb();
+  });
+};
+
+/**
+ * Fetch number of cached files.
+ *
+ * @param {Function} fn
+ * @api public
+ */
+
+MemoryStore.prototype.length = function(cb){
+  cb(null, Object.keys(this.assets).length);
+};

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -23,8 +23,8 @@ var fs = require('fs'),
     MemoryStore = require('./memory'),
     StoreStream = require('./storeStream'),
     FileAsset = require('./fileAsset'),
-    mime = require('mime'),
-    send = require('send')
+    send = require('send'),
+    mime = send.mime
     ;
 
 /**

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -211,11 +211,11 @@ exports = module.exports = function staticGzip(dirPath, options){
         fs.stat(filename, function(err, stat) {
 
             if (err) {
-                return pass(filename);
+                return next();
             }
 
             if (stat.isDirectory()) {
-                return pass(req.url);
+                return next();
             }
 
             if (!contentTypeMatch.test(contentType)) {

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -8,17 +8,21 @@
  * Module dependencies.
  */
 
+// Commented out as I think that connect is avalible from within express...
+// try {
+    staticMiddleware = require('connect').static;
+// } catch (e) {
+//  staticMiddleware = require('express').static;
+// }
+
 var fs = require('fs'),
-		parse = require('url').parse,
-		path = require('path'),
-		mime = require('mime'),
-		zlib = require('zlib'),
-		staticSend;
-try {
-	staticSend = require('connect').static.send;
-} catch (e) {
-	staticSend = require('express').static.send;
-}
+        parse = require('url').parse,
+        path = require('path'),
+        zlib = require('zlib'),
+        staticMiddleware;
+
+var mime = staticMiddleware.mime,
+    staticSend = staticMiddleware.send;
 
 /**
  * Strip `Content-*` headers from `res`.
@@ -28,11 +32,29 @@ try {
  */
 
 var removeContentHeaders = function(res){
-	Object.keys(res._headers).forEach(function(field){
-		if (0 === field.indexOf('content')) {
-			res.removeHeader(field);
-		}
-	});
+    Object.keys(res._headers).forEach(function(field){
+        if (0 === field.indexOf('content')) {
+            res.removeHeader(field);
+        }
+    });
+};
+
+/**
+ * Supported content-encoding methods.
+ */
+
+var methods = {
+    gzip: zlib.createGzip,
+    deflate: zlib.createDeflate
+};
+
+/**
+ * Default filter function.
+ */
+
+exports.filter = function(req, res){
+  var type = res.getHeader('Content-Type') || '';
+  return type.match(/json|text|javascript/);
 };
 
 /**
@@ -47,12 +69,12 @@ var gzippoCache = {};
 
 var gzippo = function(filename, charset, callback) {
 
-	fs.readFile(filename, function (err, data) {
-		if (err) throw err;
-			zlib.gzip(data, function(err, result) {
-				callback(result);
-			});
-	});
+    fs.readFile(filename, function (err, data) {
+        if (err) throw err;
+        zlib.gzip(data, function(err, result) {
+            callback(result);
+        });
+    });
 
 
 };
@@ -63,11 +85,11 @@ var gzippo = function(filename, charset, callback) {
  *
  * Options:
  *
- *	-	`maxAge` how long gzippo should cache gziped assets, defaulting to 1 day
- *	-	`clientMaxAge`  client cache-control max-age directive, defaulting to 1 week
- *	-	`contentTypeMatch` - A regular expression tested against the Content-Type header to determine whether the response
- *		should be gzipped or not. The default value is `/text|javascript|json/`.
- *	-	`prefix` - A url prefix. If you want all your static content in a root path such as /resource/. Any url paths not matching will be ignored
+ *  -   `maxAge` how long gzippo should cache gziped assets, defaulting to 1 day
+ *  -   `clientMaxAge`  client cache-control max-age directive, defaulting to 0; 604800000 is one week.
+ *  -   `contentTypeMatch` - A regular expression tested against the Content-Type header to determine whether the response
+ *      should be gzipped or not. The default value is `/text|javascript|json/`.
+ *  -   `prefix` - A url prefix. If you want all your static content in a root path such as /resource/. Any url paths not matching will be ignored
  *
  * Examples:
  *
@@ -86,113 +108,156 @@ var gzippo = function(filename, charset, callback) {
  */
 
 exports = module.exports = function staticGzip(dirPath, options){
-	options = options || {};
-	var
-		maxAge = options.maxAge || 86400000,
-		contentTypeMatch = options.contentTypeMatch || /text|javascript|json/,
-		clientMaxAge = options.clientMaxAge || 604800000,
-		prefix = options.prefix || '';
+    options = options || {};
+    var
+        maxAge = options.maxAge || 86400000,
+        contentTypeMatch = options.contentTypeMatch || /text|javascript|json/,
+        clientMaxAge = options.clientMaxAge || 0,
+        prefix = options.prefix || '',
+        names = Object.keys(methods),
+        compressionOptions = options.compression || {};
 
-	if (!dirPath) throw new Error('You need to provide the directory to your static content.');
-	if (!contentTypeMatch.test) throw new Error('contentTypeMatch: must be a regular expression.');
+    if (!dirPath) throw new Error('You need to provide the directory to your static content.');
+    if (!contentTypeMatch.test) throw new Error('contentTypeMatch: must be a regular expression.');
 
-  return function staticGzip(req, res, next){
-		var url, filename, contentType, acceptEncoding, charset;
+    return function(req, res, next){
+        var url,
+            filename,
+            contentType,
+            acceptEncoding = req.headers['accept-encoding'],
+            charset,
+            method;
 
-		function pass(name) {
-			var o = Object.create(options);
-			o.path = name;
-			o.maxAge = clientMaxAge;
-			staticSend(req, res, next, o);
-		}
 
-		function setHeaders(cacheObj) {
-			res.setHeader('Content-Type', contentType);
-			res.setHeader('Content-Encoding', 'gzip');
-			res.setHeader('Vary', 'Accept-Encoding');
-			res.setHeader('Content-Length', cacheObj.content.length);
-			res.setHeader('Last-Modified', cacheObj.mtime.toUTCString());
-			res.setHeader('Date', new Date().toUTCString());
-			res.setHeader('Expires', new Date(Date.now() + clientMaxAge).toUTCString());
-			res.setHeader('Cache-Control', 'public, max-age=' + (clientMaxAge / 1000));
-			res.setHeader('ETag', '"' + cacheObj.content.length + '-' + Number(cacheObj.mtime) + '"');
-		}
+        function pass(name) {
+            var o = Object.create(options);
+            o.path = name;
+            o.maxAge = clientMaxAge;
+            staticSend(req, res, next, o);
+        }
 
-		function sendGzipped(cacheObj) {
-			setHeaders(cacheObj);
-			res.end(cacheObj.content, 'binary');
-		}
+        function setHeaders(stat) {
+            res.setHeader('Content-Type', contentType);
+            res.setHeader('Content-Encoding', 'gzip');
+            res.setHeader('Vary', 'Accept-Encoding');
+            // if cache version is avalible then add this.
+            // res.setHeader('Content-Length', stat.length);
+            // res.setHeader('ETag', '"' + stat.length + '-' + Number(stat.mtime) + '"');
+            res.setHeader('Last-Modified', stat.mtime.toUTCString());
+            res.setHeader('Date', new Date().toUTCString());
+            res.setHeader('Expires', new Date(Date.now() + clientMaxAge).toUTCString());
+            res.setHeader('Cache-Control', 'public, max-age=' + (clientMaxAge / 1000));
+        }
 
-		function gzipAndSend(filename, gzipName, mtime) {
-			gzippo(filename, charset, function(gzippedData) {
-				gzippoCache[gzipName] = {
-					'ctime': Date.now(),
-					'mtime': mtime,
-					'content': gzippedData
-				};
-				sendGzipped(gzippoCache[gzipName]);
-			});
-		}
+        function sendGzipped(cacheObj) {
+            setHeaders(cacheObj);
+            res.end(cacheObj.content, 'binary');
+        }
 
-		if (req.method !== 'GET' && req.method !== 'HEAD') {
-			return next();
-		}
+        function gzipAndSend(filename, gzipName, mtime) {
+            gzippo(filename, charset, function(gzippedData) {
+                gzippoCache[gzipName] = {
+                    'ctime': Date.now(),
+                    'mtime': mtime,
+                    'content': gzippedData
+                };
+                sendGzipped(gzippoCache[gzipName]);
+            });
+        }
 
-		url = parse(req.url);
+        if (req.method !== 'GET' && req.method !== 'HEAD') {
+            return next();
+        }
 
-		// Allow a url path prefix
-		if (url.pathname.substring(0, prefix.length) !== prefix) {
-			return next();
-		}
+        url = parse(req.url);
 
-		filename = path.join(dirPath, url.pathname.substring(prefix.length));
+        // Allow a url path prefix
+        if (url.pathname.substring(0, prefix.length) !== prefix) {
+            return next();
+        }
 
-		contentType = mime.lookup(filename);
-		charset = mime.charsets.lookup(contentType, 'UTF-8');
-		contentType = contentType + (charset ? '; charset=' + charset : '');
-		acceptEncoding = req.headers['accept-encoding'] || '';
+        filename = path.join(dirPath, url.pathname.substring(prefix.length));
 
-		//This is storing in memory for the moment, need to think what the best way to do this.
-		//Check file is not a directory
+        contentType = mime.lookup(filename);
+        charset = mime.charsets.lookup(contentType, 'UTF-8');
+        contentType = contentType + (charset ? '; charset=' + charset : '');
 
-		fs.stat(decodeURI(filename), function(err, stat) {
+        // default to gzip
+        if ('*' == acceptEncoding.trim()) method = 'gzip';
 
-			if (err || stat.isDirectory()) {
-				return pass(req.url);
-			}
+        // compression method
+        if (!method) {
+            for (var i = 0, len = names.length; i < len; ++i) {
+              if (~acceptEncoding.indexOf(names[i])) {
+                method = names[i];
+                break;
+              }
+            }
+        }
 
-			if (!contentTypeMatch.test(contentType)) {
-				return pass(filename);
-			}
+        // compression method
+        if (!method) return pass(filename);
 
-			if (!~acceptEncoding.indexOf('gzip')) {
-				return pass(filename);
-			}
+        fs.stat(decodeURI(filename), function(err, stat) {
 
-			var base = path.basename(filename),
-					dir = path.dirname(filename),
-					gzipName = path.join(dir, base + '.gz');
+            if (err || stat.isDirectory()) {
+                return pass(req.url);
+            }
 
-			if (req.headers['if-modified-since'] &&
-				gzippoCache[gzipName] &&
-				+stat.mtime <= new Date(req.headers['if-modified-since']).getTime()) {
-				setHeaders(gzippoCache[gzipName]);
-				removeContentHeaders(res);
-				res.statusCode = 304;
-				return res.end();
-			}
+            if (!contentTypeMatch.test(contentType)) {
+                return pass(filename);
+            }
 
-			//TODO: check for pre-compressed file
-			if (typeof gzippoCache[gzipName] === 'undefined') {
-				gzipAndSend(filename, gzipName, stat.mtime);
-			} else {
-				if ((gzippoCache[gzipName].mtime < stat.mtime) ||
-				((gzippoCache[gzipName].ctime + maxAge) < Date.now())) {
-					gzipAndSend(filename, gzipName, stat.mtime);
-				} else {
-					sendGzipped(gzippoCache[gzipName]);
-				}
-			}
-		});
-	};
+            // superceeded by if (!method) return;
+            // if (!~acceptEncoding.indexOf('gzip')) {
+            //     return pass(filename);
+            // }
+
+            var base = path.basename(filename),
+                dir = path.dirname(filename),
+                gzipName = path.join(dir, base + '.gz');
+
+            if (req.headers['if-modified-since'] &&
+                gzippoCache[gzipName] &&
+                +stat.mtime <= new Date(req.headers['if-modified-since']).getTime()) {
+                setHeaders(gzippoCache[gzipName]);
+                removeContentHeaders(res);
+                res.statusCode = 304;
+                return res.end();
+            }
+
+            setHeaders(stat);
+
+            // stream needs caching stream
+            var stream = fs.createReadStream(decodeURI(filename));
+
+            req.emit('static', stream);
+            req.on('close', stream.destroy.bind(stream));
+
+            compressionStream = methods[method](options.compression);
+
+            stream.pipe(compressionStream).pipe(res);
+
+            stream.on('error', function(err){
+                if (res.headerSent) {
+                    console.error(err.stack);
+                    req.destroy();
+                } else {
+                    next(err);
+                }
+            });
+
+            //TODO: Handle caching
+            // if (typeof gzippoCache[gzipName] === 'undefined') {
+            //  gzipAndSend(filename, gzipName, stat.mtime);
+            // } else {
+            //  if ((gzippoCache[gzipName].mtime < stat.mtime) ||
+            //  ((gzippoCache[gzipName].ctime + maxAge) < Date.now())) {
+            //      gzipAndSend(filename, gzipName, stat.mtime);
+            //  } else {
+            //      sendGzipped(gzippoCache[gzipName]);
+            //  }
+            // }
+        });
+    };
 };

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -10,16 +10,17 @@
 
 // Commented out as I think that connect is avalible from within express...
 // try {
-    staticMiddleware = require('connect').static;
+    var staticMiddleware = require('connect').static;
 // } catch (e) {
 //  staticMiddleware = require('express').static;
 // }
 
 var fs = require('fs'),
-        parse = require('url').parse,
-        path = require('path'),
-        zlib = require('zlib'),
-        staticMiddleware;
+    parse = require('url').parse,
+    path = require('path'),
+    zlib = require('zlib'),
+    MemoryStore = require('./memory'),
+    FileAsset = require('./fileAsset');
 
 var mime = staticMiddleware.mime,
     staticSend = staticMiddleware.send;
@@ -58,28 +59,6 @@ exports.filter = function(req, res){
 };
 
 /**
- * gzipped cache.
- */
-
-var gzippoCache = {};
-
-/**
- * gzip file.
- */
-
-var gzippo = function(filename, charset, callback) {
-
-    fs.readFile(filename, function (err, data) {
-        if (err) throw err;
-        zlib.gzip(data, function(err, result) {
-            callback(result);
-        });
-    });
-
-
-};
-
-/**
  * By default gzip's static's that match the given regular expression /text|javascript|json/
  * and then serves them with Connects static provider, denoted by the given `dirPath`.
  *
@@ -109,22 +88,23 @@ var gzippo = function(filename, charset, callback) {
 
 exports = module.exports = function staticGzip(dirPath, options){
     options = options || {};
-    var
-        maxAge = options.maxAge || 86400000,
+
+    var maxAge = options.maxAge || 86400000,
         contentTypeMatch = options.contentTypeMatch || /text|javascript|json/,
         clientMaxAge = options.clientMaxAge || 0,
         prefix = options.prefix || '',
         names = Object.keys(methods),
-        compressionOptions = options.compression || {};
+        compressionOptions = options.compression || {},
+        store = options.store || new MemoryStore();
 
     if (!dirPath) throw new Error('You need to provide the directory to your static content.');
     if (!contentTypeMatch.test) throw new Error('contentTypeMatch: must be a regular expression.');
 
-    return function(req, res, next){
-        var url,
+    return function(req, res, next) {
+        var acceptEncoding = req.headers['accept-encoding'],
+            url,
             filename,
             contentType,
-            acceptEncoding = req.headers['accept-encoding'],
             charset,
             method;
 
@@ -136,34 +116,31 @@ exports = module.exports = function staticGzip(dirPath, options){
             staticSend(req, res, next, o);
         }
 
-        function setHeaders(stat) {
+        function setHeaders(stat, asset) {
             res.setHeader('Content-Type', contentType);
-            res.setHeader('Content-Encoding', 'gzip');
+            res.setHeader('Content-Encoding', method);
             res.setHeader('Vary', 'Accept-Encoding');
             // if cache version is avalible then add this.
-            // res.setHeader('Content-Length', stat.length);
-            // res.setHeader('ETag', '"' + stat.length + '-' + Number(stat.mtime) + '"');
-            res.setHeader('Last-Modified', stat.mtime.toUTCString());
+            if (asset) {
+                res.setHeader('Content-Length', asset.content.length);
+                res.setHeader('ETag', '"' + asset.content.length + '-' + Number(asset.mtime) + '"');
+            }
+            res.setHeader('Last-Modified', asset.mtime.toUTCString());
             res.setHeader('Date', new Date().toUTCString());
             res.setHeader('Expires', new Date(Date.now() + clientMaxAge).toUTCString());
             res.setHeader('Cache-Control', 'public, max-age=' + (clientMaxAge / 1000));
         }
 
-        function sendGzipped(cacheObj) {
-            setHeaders(cacheObj);
-            res.end(cacheObj.content, 'binary');
-        }
-
-        function gzipAndSend(filename, gzipName, mtime) {
-            gzippo(filename, charset, function(gzippedData) {
-                gzippoCache[gzipName] = {
-                    'ctime': Date.now(),
-                    'mtime': mtime,
-                    'content': gzippedData
-                };
-                sendGzipped(gzippoCache[gzipName]);
-            });
-        }
+        // function gzipAndSend(filename, gzipName, mtime) {
+        //     gzippo(filename, charset, function(gzippedData) {
+        //         gzippoCache[gzipName] = {
+        //             'ctime': Date.now(),
+        //             'mtime': mtime,
+        //             'content': gzippedData
+        //         };
+        //         sendGzipped(gzippoCache[gzipName]);
+        //     });
+        // }
 
         if (req.method !== 'GET' && req.method !== 'HEAD') {
             return next();
@@ -195,7 +172,6 @@ exports = module.exports = function staticGzip(dirPath, options){
             }
         }
 
-        // compression method
         if (!method) return pass(filename);
 
         fs.stat(decodeURI(filename), function(err, stat) {
@@ -217,47 +193,57 @@ exports = module.exports = function staticGzip(dirPath, options){
                 dir = path.dirname(filename),
                 gzipName = path.join(dir, base + '.gz');
 
-            if (req.headers['if-modified-since'] &&
-                gzippoCache[gzipName] &&
+            var sendGzipped = function(filename) {
+                var stream = fs.createReadStream(filename);
+
+                asset = new FileAsset(filename, stat.mtime);
+
+                asset.maxAge = options.maxAge;
+
+                req.on('close', stream.destroy.bind(stream));
+
+                var compressionStream = methods[method](options.compression);
+
+                stream.pipe(compressionStream).pipe(res);
+
+                compressionStream.on('data', function(data) {
+                    asset.content = data;
+                });
+
+                compressionStream.on('end', function() {
+                    store.set(asset);
+                });
+
+                stream.on('error', function(err){
+                    if (res.headerSent) {
+                        console.error(err.stack);
+                        req.destroy();
+                    } else {
+                        next(err);
+                    }
+                });
+            };
+
+            store.get(decodeURI(filename), function(err, asset) {
+                setHeaders(stat, asset);
+                if (err) {
+                    // handle error
+
+                } else if (!asset) {
+                    sendGzipped(decodeURI(filename));
+                } else if ((asset.mtime < stat.mtime) || asset.isExpired) {
+                    sendGzipped(decodeURI(filename));
+                }
+                else if (req.headers['if-modified-since'] &&
+                // Optimisation: new Date().getTime is 90% faster that Date.parse()
                 +stat.mtime <= new Date(req.headers['if-modified-since']).getTime()) {
-                setHeaders(gzippoCache[gzipName]);
-                removeContentHeaders(res);
-                res.statusCode = 304;
-                return res.end();
-            }
-
-            setHeaders(stat);
-
-            // stream needs caching stream
-            var stream = fs.createReadStream(decodeURI(filename));
-
-            req.emit('static', stream);
-            req.on('close', stream.destroy.bind(stream));
-
-            compressionStream = methods[method](options.compression);
-
-            stream.pipe(compressionStream).pipe(res);
-
-            stream.on('error', function(err){
-                if (res.headerSent) {
-                    console.error(err.stack);
-                    req.destroy();
+                    removeContentHeaders(res);
+                    res.statusCode = 304;
+                    return res.end();
                 } else {
-                    next(err);
+                    res.end(asset.content);
                 }
             });
-
-            //TODO: Handle caching
-            // if (typeof gzippoCache[gzipName] === 'undefined') {
-            //  gzipAndSend(filename, gzipName, stat.mtime);
-            // } else {
-            //  if ((gzippoCache[gzipName].mtime < stat.mtime) ||
-            //  ((gzippoCache[gzipName].ctime + maxAge) < Date.now())) {
-            //      gzipAndSend(filename, gzipName, stat.mtime);
-            //  } else {
-            //      sendGzipped(gzippoCache[gzipName]);
-            //  }
-            // }
         });
     };
 };

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -10,7 +10,8 @@
 
 // Commented out as I think that connect is avalible from within express...
 // try {
-    var staticMiddleware = require('connect').static;
+    // var staticMiddleware = require('connect').static;
+
 // } catch (e) {
 //  staticMiddleware = require('express').static;
 // }
@@ -23,8 +24,9 @@ var fs = require('fs'),
     StoreStream = require('./storeStream'),
     FileAsset = require('./fileAsset');
 
-var mime = staticMiddleware.mime,
-    staticSend = staticMiddleware.send;
+var mime = require('mime'),
+    send = require('send')
+    ;
 
 /**
  * Strip `Content-*` headers from `res`.
@@ -60,6 +62,23 @@ exports.filter = function(req, res){
 };
 
 /**
+ * Parse the `req` url with memoization.
+ *
+ * @param {ServerRequest} req
+ * @return {Object}
+ * @api private
+ */
+
+var parseUrl = function(req){
+  var parsed = req._parsedUrl;
+  if (parsed && parsed.href == req.url) {
+    return parsed;
+  } else {
+    return req._parsedUrl = parse(req.url);
+  }
+};
+
+/**
  * By default gzip's static's that match the given regular expression /text|javascript|json/
  * and then serves them with Connects static provider, denoted by the given `dirPath`.
  *
@@ -92,7 +111,7 @@ exports = module.exports = function staticGzip(dirPath, options){
 
     var maxAge = options.maxAge || 86400000,
         contentTypeMatch = options.contentTypeMatch || /text|javascript|json/,
-        clientMaxAge = options.clientMaxAge || 0,
+        clientMaxAge = options.clientMaxAge || 604800000,
         prefix = options.prefix || '',
         names = Object.keys(methods),
         compressionOptions = options.compression || {},
@@ -114,7 +133,13 @@ exports = module.exports = function staticGzip(dirPath, options){
             var o = Object.create(options);
             o.path = name;
             o.maxAge = clientMaxAge;
-            staticSend(req, res, next, o);
+            var urlReq = parseUrl(req).pathname;
+            console.log(dirPath + urlReq);
+            send(req, urlReq)
+                .maxage(clientMaxAge || 0)
+                .root(dirPath)
+                .pipe(res)
+                ;
         }
 
         function setHeaders(stat, asset) {

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -22,9 +22,8 @@ var fs = require('fs'),
     zlib = require('zlib'),
     MemoryStore = require('./memory'),
     StoreStream = require('./storeStream'),
-    FileAsset = require('./fileAsset');
-
-var mime = require('mime'),
+    FileAsset = require('./fileAsset'),
+    mime = require('mime'),
     send = require('send')
     ;
 

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -120,6 +120,8 @@ exports = module.exports = function staticGzip(dirPath, options){
     if (!dirPath) throw new Error('You need to provide the directory to your static content.');
     if (!contentTypeMatch.test) throw new Error('contentTypeMatch: must be a regular expression.');
 
+    dirPath = path.normalize(dirPath);
+
     return function(req, res, next) {
         var acceptEncoding = req.headers['accept-encoding'] || '',
             url,
@@ -164,6 +166,14 @@ exports = module.exports = function staticGzip(dirPath, options){
         //     });
         // }
 
+        function forbidden(res) {
+          var body = 'Forbidden';
+          res.setHeader('Content-Type', 'text/plain');
+          res.setHeader('Content-Length', body.length);
+          res.statusCode = 403;
+          res.end(body);
+        };
+
         if (req.method !== 'GET' && req.method !== 'HEAD') {
             return next();
         }
@@ -175,7 +185,11 @@ exports = module.exports = function staticGzip(dirPath, options){
             return next();
         }
 
-        filename = path.join(dirPath, url.pathname.substring(prefix.length));
+        filename = path.normalize(path.join(dirPath, url.pathname.substring(prefix.length)));
+        // malicious path
+        if (0 != filename.indexOf(dirPath)){
+          return forbidden(res);
+        }
 
         contentType = mime.lookup(filename);
         charset = mime.charsets.lookup(contentType, 'UTF-8');

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -129,18 +129,12 @@ exports = module.exports = function staticGzip(dirPath, options){
             charset,
             method;
 
-        function pass(name) {
-            send(req, url.substring(prefix.length))
-                .maxage(clientMaxAge || 0)
-                .root(dirPath)
-                .pipe(res)
-                ;
-        }
-
         function setHeaders(stat, asset) {
             res.setHeader('Content-Type', contentType);
-            res.setHeader('Content-Encoding', method);
-            res.setHeader('Vary', 'Accept-Encoding');
+            if (method) {
+                res.setHeader('Content-Encoding', method);
+                res.setHeader('Vary', 'Accept-Encoding');
+            }
             // if cache version is avalible then add this.
             if (asset) {
                 // res.setHeader('Content-Length', asset.length);
@@ -191,25 +185,24 @@ exports = module.exports = function staticGzip(dirPath, options){
         // directory index file support
         if (filename.substr(-1) === '/') filename += 'index.html';
 
-
         contentType = mime.lookup(filename);
         charset = mime.charsets.lookup(contentType, 'UTF-8');
         contentType = contentType + (charset ? '; charset=' + charset : '');
 
-        // default to gzip
-        if ('*' == acceptEncoding.trim()) method = 'gzip';
+        if (contentTypeMatch.test(contentType)) {
+            // default to gzip
+            if ('*' == acceptEncoding.trim()) method = 'gzip';
 
-        // compression method
-        if (!method) {
-            for (var i = 0, len = names.length; i < len; ++i) {
-              if (~acceptEncoding.indexOf(names[i])) {
-                method = names[i];
-                break;
-              }
+            // compression method
+            if (!method) {
+                for (var i = 0, len = names.length; i < len; ++i) {
+                    if (~acceptEncoding.indexOf(names[i])) {
+                        method = names[i];
+                        break;
+                    }
+                }
             }
         }
-
-        if (!method) return pass(filename);
 
         fs.stat(filename, function(err, stat) {
 
@@ -219,10 +212,6 @@ exports = module.exports = function staticGzip(dirPath, options){
 
             if (stat.isDirectory()) {
                 return next();
-            }
-
-            if (!contentTypeMatch.test(contentType)) {
-                return pass(filename);
             }
 
             // superceeded by if (!method) return;
@@ -244,9 +233,14 @@ exports = module.exports = function staticGzip(dirPath, options){
                     maxAge: options.maxAge
                 });
 
-                var compressionStream = methods[method](options.compression);
+                if (method) {
+                    var compressionStream = methods[method](options.compression);
 
-                stream.pipe(compressionStream).pipe(storeStream).pipe(res);
+                    stream.pipe(compressionStream).pipe(storeStream).pipe(res);
+                }
+                else {
+                    stream.pipe(storeStream).pipe(res);
+                }
 
                 stream.on('error', function(err){
                     if (res.headerSent) {

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -20,6 +20,7 @@ var fs = require('fs'),
     path = require('path'),
     zlib = require('zlib'),
     MemoryStore = require('./memory'),
+    StoreStream = require('./storeStream'),
     FileAsset = require('./fileAsset');
 
 var mime = staticMiddleware.mime,
@@ -122,10 +123,10 @@ exports = module.exports = function staticGzip(dirPath, options){
             res.setHeader('Vary', 'Accept-Encoding');
             // if cache version is avalible then add this.
             if (asset) {
-                res.setHeader('Content-Length', asset.content.length);
-                res.setHeader('ETag', '"' + asset.content.length + '-' + Number(asset.mtime) + '"');
+                // res.setHeader('Content-Length', asset.length);
+                res.setHeader('ETag', '"' + asset.length + '-' + Number(asset.mtime) + '"');
+                res.setHeader('Last-Modified', asset.mtime.toUTCString());
             }
-            res.setHeader('Last-Modified', asset.mtime.toUTCString());
             res.setHeader('Date', new Date().toUTCString());
             res.setHeader('Expires', new Date(Date.now() + clientMaxAge).toUTCString());
             res.setHeader('Cache-Control', 'public, max-age=' + (clientMaxAge / 1000));
@@ -202,16 +203,23 @@ exports = module.exports = function staticGzip(dirPath, options){
 
                 req.on('close', stream.destroy.bind(stream));
 
+                var storeStream = new StoreStream(store);
+
                 var compressionStream = methods[method](options.compression);
 
-                stream.pipe(compressionStream).pipe(res);
+                // var cacheStream = asset
 
-                compressionStream.on('data', function(data) {
-                    asset.content = data;
+                stream.pipe(compressionStream).pipe(storeStream).pipe(res);
+
+                storeStream.on('data', function(chunk) {
+                    console.log('data: ' + asset.name);
+                    // asset.fileContents.push(chunk);
+                    // asset.fileContentsLength += chunk.length;
                 });
 
-                compressionStream.on('end', function() {
-                    store.set(asset);
+                storeStream.on('end', function() {
+                    console.log('end: ' + asset.name);
+                    // store.set(asset);
                 });
 
                 stream.on('error', function(err){
@@ -234,14 +242,30 @@ exports = module.exports = function staticGzip(dirPath, options){
                 } else if ((asset.mtime < stat.mtime) || asset.isExpired) {
                     sendGzipped(decodeURI(filename));
                 }
-                else if (req.headers['if-modified-since'] &&
-                // Optimisation: new Date().getTime is 90% faster that Date.parse()
-                +stat.mtime <= new Date(req.headers['if-modified-since']).getTime()) {
-                    removeContentHeaders(res);
-                    res.statusCode = 304;
-                    return res.end();
-                } else {
-                    res.end(asset.content);
+                // else if (req.headers['if-modified-since'] && asset &&
+                // // Optimisation: new Date().getTime is 90% faster that Date.parse()
+                // +stat.mtime <= new Date(req.headers['if-modified-since']).getTime()) {
+                //     removeContentHeaders(res);
+                //     res.statusCode = 304;
+                //     return res.end();
+                // }
+                else {
+                    // res.end(asset.content);
+                    // while (true) {
+                    //     console.log(asset.content);
+                    //     if (asset.content) {
+                    //         res.write(asset.content);
+                    //     } else {
+                    //         res.end();
+                    //         return;
+                    //     }
+                    // }
+                    // res.write(asset.content);
+                    console.log("hit: " + filename + "              length: " + asset.length);
+                    for (var i = 0; i < asset.content.length; i++) {
+                        res.write(asset.content[i], 'binary');
+                    }
+                    res.end();
                 }
             });
         });

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -197,30 +197,16 @@ exports = module.exports = function staticGzip(dirPath, options){
             var sendGzipped = function(filename) {
                 var stream = fs.createReadStream(filename);
 
-                asset = new FileAsset(filename, stat.mtime);
-
-                asset.maxAge = options.maxAge;
-
                 req.on('close', stream.destroy.bind(stream));
 
-                var storeStream = new StoreStream(store);
+                var storeStream = new StoreStream(store, filename, {
+                    mtime: stat.mtime,
+                    maxAge: options.maxAge
+                });
 
                 var compressionStream = methods[method](options.compression);
 
-                // var cacheStream = asset
-
                 stream.pipe(compressionStream).pipe(storeStream).pipe(res);
-
-                storeStream.on('data', function(chunk) {
-                    console.log('data: ' + asset.name);
-                    // asset.fileContents.push(chunk);
-                    // asset.fileContentsLength += chunk.length;
-                });
-
-                storeStream.on('end', function() {
-                    console.log('end: ' + asset.name);
-                    // store.set(asset);
-                });
 
                 stream.on('error', function(err){
                     if (res.headerSent) {
@@ -242,25 +228,15 @@ exports = module.exports = function staticGzip(dirPath, options){
                 } else if ((asset.mtime < stat.mtime) || asset.isExpired) {
                     sendGzipped(decodeURI(filename));
                 }
-                // else if (req.headers['if-modified-since'] && asset &&
-                // // Optimisation: new Date().getTime is 90% faster that Date.parse()
-                // +stat.mtime <= new Date(req.headers['if-modified-since']).getTime()) {
-                //     removeContentHeaders(res);
-                //     res.statusCode = 304;
-                //     return res.end();
-                // }
+                else if (req.headers['if-modified-since'] && asset &&
+                // Optimisation: new Date().getTime is 90% faster that Date.parse()
+                +stat.mtime <= new Date(req.headers['if-modified-since']).getTime()) {
+                    removeContentHeaders(res);
+                    res.statusCode = 304;
+                    return res.end();
+                }
                 else {
-                    // res.end(asset.content);
-                    // while (true) {
-                    //     console.log(asset.content);
-                    //     if (asset.content) {
-                    //         res.write(asset.content);
-                    //     } else {
-                    //         res.end();
-                    //         return;
-                    //     }
-                    // }
-                    // res.write(asset.content);
+                    // StoreReadStream to pipe to res.
                     console.log("hit: " + filename + "              length: " + asset.length);
                     for (var i = 0; i < asset.content.length; i++) {
                         res.write(asset.content[i], 'binary');

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -188,6 +188,9 @@ exports = module.exports = function staticGzip(dirPath, options){
           return forbidden(res);
         }
 
+        // directory index file support
+        if (filename.substr(-1) === '/') filename += 'index.html';
+
 
         contentType = mime.lookup(filename);
         charset = mime.charsets.lookup(contentType, 'UTF-8');

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -102,7 +102,7 @@ exports = module.exports = function staticGzip(dirPath, options){
     if (!contentTypeMatch.test) throw new Error('contentTypeMatch: must be a regular expression.');
 
     return function(req, res, next) {
-        var acceptEncoding = req.headers['accept-encoding'],
+        var acceptEncoding = req.headers['accept-encoding'] || '',
             url,
             filename,
             contentType,

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -130,11 +130,7 @@ exports = module.exports = function staticGzip(dirPath, options){
 
 
         function pass(name) {
-            var o = Object.create(options);
-            o.path = name;
-            o.maxAge = clientMaxAge;
             var urlReq = parseUrl(req).pathname;
-            console.log(dirPath + urlReq);
             send(req, urlReq)
                 .maxage(clientMaxAge || 0)
                 .root(dirPath)
@@ -262,7 +258,7 @@ exports = module.exports = function staticGzip(dirPath, options){
                 }
                 else {
                     // StoreReadStream to pipe to res.
-                    console.log("hit: " + filename + "              length: " + asset.length);
+                    // console.log("hit: " + filename + "              length: " + asset.length);
                     for (var i = 0; i < asset.content.length; i++) {
                         res.write(asset.content[i], 'binary');
                     }

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -130,7 +130,7 @@ exports = module.exports = function staticGzip(dirPath, options){
             method;
 
         function pass(name) {
-            send(req, url)
+            send(req, url.substring(prefix.length))
                 .maxage(clientMaxAge || 0)
                 .root(dirPath)
                 .pipe(res)

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -130,10 +130,8 @@ exports = module.exports = function staticGzip(dirPath, options){
             charset,
             method;
 
-
         function pass(name) {
-            var urlReq = parseUrl(req).pathname;
-            send(req, urlReq)
+            send(req, url)
                 .maxage(clientMaxAge || 0)
                 .root(dirPath)
                 .pipe(res)
@@ -172,24 +170,25 @@ exports = module.exports = function staticGzip(dirPath, options){
           res.setHeader('Content-Length', body.length);
           res.statusCode = 403;
           res.end(body);
-        };
+        }
 
         if (req.method !== 'GET' && req.method !== 'HEAD') {
             return next();
         }
 
-        url = parse(req.url);
+        url = decodeURI(parseUrl(req).pathname);
 
         // Allow a url path prefix
-        if (url.pathname.substring(0, prefix.length) !== prefix) {
+        if (url.substring(0, prefix.length) !== prefix) {
             return next();
         }
 
-        filename = path.normalize(path.join(dirPath, url.pathname.substring(prefix.length)));
+        filename = path.normalize(path.join(dirPath, url.substring(prefix.length)));
         // malicious path
         if (0 != filename.indexOf(dirPath)){
           return forbidden(res);
         }
+
 
         contentType = mime.lookup(filename);
         charset = mime.charsets.lookup(contentType, 'UTF-8');
@@ -210,9 +209,13 @@ exports = module.exports = function staticGzip(dirPath, options){
 
         if (!method) return pass(filename);
 
-        fs.stat(decodeURI(filename), function(err, stat) {
+        fs.stat(filename, function(err, stat) {
 
-            if (err || stat.isDirectory()) {
+            if (err) {
+                return pass(filename);
+            }
+
+            if (stat.isDirectory()) {
                 return pass(req.url);
             }
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,0 +1,8 @@
+
+/*
+ * gzippo - store
+ * Copyright(c) 2012 Tom Gallacher
+ * MIT Licensed
+ */
+
+var Store = module.exports = function Store(options) {};

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,3 +1,4 @@
+var util = require('util');
 
 /*
  * gzippo - store
@@ -5,4 +6,6 @@
  * MIT Licensed
  */
 
-var Store = module.exports = function Store(options) {};
+var Store = module.exports = function Store(options) {
+  if (!(this instanceof Store)) return new Store(options);
+};

--- a/lib/storeStream.js
+++ b/lib/storeStream.js
@@ -63,7 +63,6 @@ StoreStream.prototype.end = function end(chunk, cb) {
   var ret = this.write(chunk, function() {
     self.emit('end');
     process.nextTick(function() {
-      console.log(self._asset);
       self._store.set(self._asset);
     });
     if (cb) cb();

--- a/lib/storeStream.js
+++ b/lib/storeStream.js
@@ -1,5 +1,6 @@
-var util = require('util');
-var stream = require('stream');
+var util = require('util'),
+    stream = require('stream'),
+    FileAsset = require('./fileAsset');
 
 /*
  * gzippo - StoreStream
@@ -7,13 +8,17 @@ var stream = require('stream');
  * MIT Licensed
  */
 
-var StoreStream = module.exports = function StoreStream(store) {
-  if (!(this instanceof StoreStream)) return new StoreStream(store);
+var StoreStream = module.exports = function StoreStream(store, fileName, options) {
+  if (!(this instanceof StoreStream)) return new StoreStream(store, options);
+  options = options || {};
+
   this._queue = [];
   this._processing = false;
   this._ended = false;
   this.readable = true;
   this.writable = true;
+
+  this._asset = new FileAsset(fileName, options);
   this._store = store;
 };
 
@@ -57,6 +62,10 @@ StoreStream.prototype.end = function end(chunk, cb) {
   this._ending = true;
   var ret = this.write(chunk, function() {
     self.emit('end');
+    process.nextTick(function() {
+      console.log(self._asset);
+      self._store.set(self._asset);
+    });
     if (cb) cb();
   });
   this._ended = true;
@@ -83,8 +92,10 @@ StoreStream.prototype._process = function() {
   if (this._ending && this._queue.length === 0) {
     this._flush = true;
   }
+
   if (chunk !== null) {
     self.emit('data', chunk);
+    this._asset.fileContents.push(chunk);
   }
 
   // finished with the chunk.

--- a/lib/storeStream.js
+++ b/lib/storeStream.js
@@ -1,0 +1,104 @@
+var util = require('util');
+var stream = require('stream');
+
+/*
+ * gzippo - StoreStream
+ * Copyright(c) 2012 Tom Gallacher
+ * MIT Licensed
+ */
+
+var StoreStream = module.exports = function StoreStream(store) {
+  if (!(this instanceof StoreStream)) return new StoreStream(store);
+  this._queue = [];
+  this._processing = false;
+  this._ended = false;
+  this.readable = true;
+  this.writable = true;
+  this._store = store;
+};
+
+util.inherits(StoreStream, stream.Stream);
+
+StoreStream.prototype.write = function write(chunk, cb) {
+  if (this._ended) {
+    return this.emit('error', new Error('Cannot write after end'));
+  }
+
+  if (arguments.length === 1 && typeof chunk === 'function') {
+    cb = chunk;
+    chunk = null;
+  }
+
+  if (!chunk) {
+    chunk = null;
+  } else if (typeof chunk === 'string') {
+    chunk = new Buffer(chunk);
+  } else if (!Buffer.isBuffer(chunk)) {
+    return this.emit('error', new Error('Invalid argument'));
+  }
+
+
+  var empty = this._queue.length === 0;
+
+  this._queue.push([chunk, cb]);
+  this._process();
+  if (!empty) {
+    this._needDrain = true;
+  }
+  return empty;
+};
+
+StoreStream.prototype.flush = function flush(cb) {
+  return this.write(cb);
+};
+
+StoreStream.prototype.end = function end(chunk, cb) {
+  var self = this;
+  this._ending = true;
+  var ret = this.write(chunk, function() {
+    self.emit('end');
+    if (cb) cb();
+  });
+  this._ended = true;
+  return ret;
+};
+
+StoreStream.prototype._process = function() {
+  var self = this;
+  if (this._processing || this._paused) return;
+
+  if (this._queue.length === 0) {
+    if (this._needDrain) {
+      this._needDrain = false;
+      this.emit('drain');
+    }
+    // nothing to do, waiting for more data at this point.
+    return;
+  }
+
+  var req = this._queue.shift();
+  var cb = req.pop();
+  var chunk = req.pop();
+
+  if (this._ending && this._queue.length === 0) {
+    this._flush = true;
+  }
+  if (chunk !== null) {
+    self.emit('data', chunk);
+  }
+
+  // finished with the chunk.
+  self._processing = false;
+  if (cb) cb();
+  self._process();
+};
+
+StoreStream.prototype.pause = function() {
+  this._paused = true;
+  this.emit('pause');
+};
+
+StoreStream.prototype.resume = function() {
+  this._paused = false;
+  this._process();
+};

--- a/lib/storeStream.js
+++ b/lib/storeStream.js
@@ -103,6 +103,11 @@ StoreStream.prototype._process = function() {
   self._process();
 };
 
+StoreStream.prototype.destory = function() {
+  this._paused = true;
+  StoreStream.prototype.end.call(this);
+};
+
 StoreStream.prototype.pause = function() {
   this._paused = true;
   this.emit('pause');

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   , "gzip"
   , "compess"
   ]
+, "keywords": [ "compession"
+  , "gzip"
+  , "compess"
+  ]
 , "engines" : { "node" : ">= 0.5 < 0.9" }
 , "scripts": { "test": "mocha"
   }

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
 		"gzip",
 		"compess"
 	],
-"engines" : { "node" : ">= 0.5 < 0.7" },
+"engines" : { "node" : ">= 0.5 < 0.9" },
 "scripts":
 	{
-		"test": "expresso"
+		"test": "mocha"
 	},
 "main" : "./index.js",
 "dependencies" :
 	{
-		"mime" : ">= 1.2"
+		"mime" : ">= 1.3"
 	},
 "devDependencies":
 	{

--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
 	},
 "main" : "./index.js",
 "dependencies" :
-	{
-		"mime" : ">= 1.3"
-	},
+	{},
 "devDependencies":
 	{
 		"expresso": ">= 0.9",

--- a/package.json
+++ b/package.json
@@ -18,16 +18,16 @@
 "engines" : { "node" : ">= 0.5 < 0.9" },
 "scripts":
 	{
-		"test": "mocha"
+		"test": "expresso"
 	},
 "main" : "./index.js",
 "dependencies" :
 	{},
 "devDependencies":
 	{
-		"expresso": ">= 0.9",
-		"should": ">= 0.3",
-		"connect": ">= 1.8",
-		"express": ">= 2.5"
+		"expresso": "*",
+		"should": "*",
+		"connect": "*",
+		"express": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   , "mime": "*"
   }
 , "devDependencies": { "should": "*"
-  , "connect": "*"
+  , "connect": "~2"
+  , "express": "~3"
   , "mocha": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   }
 , "main" : "./index.js"
 , "dependencies" : { "send": "*"
-  , "mime": "*"
   }
 , "devDependencies": { "should": "*"
   , "connect": "~2"

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
 	{},
 "devDependencies":
 	{
-		"expresso": ">= 0.9",
-		"should": ">= 0.3",
-		"connect": "*"
+		"should": "*",
+		"connect": "*",
+		"mocha": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 "engines" : { "node" : ">= 0.5 < 0.9" },
 "scripts":
 	{
-		"test": "expresso"
+		"test": "mocha"
 	},
 "main" : "./index.js",
 "dependencies" :

--- a/package.json
+++ b/package.json
@@ -1,32 +1,23 @@
-{
-  "name": "gzippo",
-  "version": "0.1.7",
-  "author": "Tom Gallacher",
-  "description": "Gzip middleware for Connect using the native zlib library in node >= 0.6",
-  "homepage": "http://www.tomg.co/gzippo",
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/tomgco/gzippo.git"
-  },
-  "keywords": [
-    "compression",
-    "gzip",
-    "compress"
-  ],
-  "engines": {
-    "node": ">= 0.5 < 0.9"
-  },
-  "scripts": {
-    "test": "expresso"
-  },
-  "main": "./index.js",
-  "dependencies": {
-    "mime": ">= 1.2"
-  },
-  "devDependencies": {
-    "expresso": ">= 0.9",
-    "should": ">= 0.3",
-    "connect": "~1"
-  },
-  "optionalDependencies": {}
+{ "name" : "gzippo"
+, "version" : "0.2.0"
+, "author" : "Tom Gallacher"
+, "description" : "Gzip middleware for Connect using the native zlib library in node >= 0.6"
+, "homepage" : "http://www.tomg.co/gzippo"
+, "repository": { "type": "git"
+  , "url": "git://github.com/tomgallacher/gzippo.git"
+  }
+, "keywords": [ "compession"
+  , "gzip"
+  , "compess"
+  ]
+, "engines" : { "node" : ">= 0.5 < 0.9" }
+, "scripts": { "test": "mocha"
+  }
+, "main" : "./index.js"
+, "dependencies" : {
+  }
+, "devDependencies": { "should": "*"
+  , "connect": "*"
+  , "mocha": "*"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 , "description" : "Gzip middleware for Connect using the native zlib library in node >= 0.6"
 , "homepage" : "http://www.tomg.co/gzippo"
 , "repository": { "type": "git"
-  , "url": "git://github.com/tomgallacher/gzippo.git"
+  , "url": "git://github.com/tomgco/gzippo.git"
   }
 , "keywords": [ "compression"
   , "gzip"

--- a/package.json
+++ b/package.json
@@ -6,13 +6,9 @@
 , "repository": { "type": "git"
   , "url": "git://github.com/tomgallacher/gzippo.git"
   }
-, "keywords": [ "compession"
+, "keywords": [ "compression"
   , "gzip"
-  , "compess"
-  ]
-, "keywords": [ "compession"
-  , "gzip"
-  , "compess"
+  , "compress"
   ]
 , "engines" : { "node" : ">= 0.5 < 0.9" }
 , "scripts": { "test": "mocha"

--- a/package.json
+++ b/package.json
@@ -1,32 +1,32 @@
 {
-"name" : "gzippo",
-"version" : "0.1.3",
-"author" : "Tom Gallacher",
-"description" : "Gzip middleware for Connect using the native zlib library in node >= 0.6",
-"homepage" : "http://www.tomg.co/gzippo",
-"repository":
-  {
-		"type": "git",
-		"url": "git://github.com/tomgallacher/gzippo.git"
+  "name": "gzippo",
+  "version": "0.1.7",
+  "author": "Tom Gallacher",
+  "description": "Gzip middleware for Connect using the native zlib library in node >= 0.6",
+  "homepage": "http://www.tomg.co/gzippo",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/tomgco/gzippo.git"
   },
-"keywords":
-	[
-		"compession",
-		"gzip",
-		"compess"
-	],
-"engines" : { "node" : ">= 0.5 < 0.9" },
-"scripts":
-	{
-		"test": "mocha"
-	},
-"main" : "./index.js",
-"dependencies" :
-	{},
-"devDependencies":
-	{
-		"should": "*",
-		"connect": "*",
-		"mocha": "*"
-	}
+  "keywords": [
+    "compression",
+    "gzip",
+    "compress"
+  ],
+  "engines": {
+    "node": ">= 0.5 < 0.9"
+  },
+  "scripts": {
+    "test": "expresso"
+  },
+  "main": "./index.js",
+  "dependencies": {
+    "mime": ">= 1.2"
+  },
+  "devDependencies": {
+    "expresso": ">= 0.9",
+    "should": ">= 0.3",
+    "connect": "~1"
+  },
+  "optionalDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,8 @@
 	{},
 "devDependencies":
 	{
-		"expresso": "*",
-		"should": "*",
-		"connect": "*",
-		"express": "*"
+		"expresso": ">= 0.9",
+		"should": ">= 0.3",
+		"connect": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 , "scripts": { "test": "mocha"
   }
 , "main" : "./index.js"
-, "dependencies" : {
+, "dependencies" : { "send": "*"
+  , "mime": "*"
   }
 , "devDependencies": { "should": "*"
   , "connect": "*"

--- a/test/fixtures/index_test/index.html
+++ b/test/fixtures/index_test/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+    <head><title>Index Test</title></head>
+    <body>
+        <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+        quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+        consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+        cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+        proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+    </body>
+</html>

--- a/test/prefix.test.js
+++ b/test/prefix.test.js
@@ -1,0 +1,67 @@
+var assert = require('assert')
+  , http = require('http')
+  , fs = require('fs')
+  , connect = require('connect')
+  , join = require('path').join
+  , gzippo = require('../')
+  ;
+var fixtures = join(__dirname, 'fixtures')
+  , port = 32124
+  , app
+  , request
+  ;
+
+// read a fixture file synchronously
+function file(name) {
+  return fs.readFileSync(join(fixtures, name));
+}
+
+describe('gzippo.statisGzip (with prefix)', function() {
+
+  it('should successfully serve a .json file with a path prefix', function(done) {
+    var app = connect.createServer();
+    app.use(gzippo.staticGzip(fixtures, { prefix: '/foo' }));
+    request = require('./request')({ port: port + 5 });
+
+    app.listen(port + 5, function() {
+      request('/foo/user.json', { 'Accept-Encoding': 'gzip' },
+        function(err, res, data) {
+          if (err) throw err;
+          assert.equal(res.statusCode, 200);
+
+          assert.equal(res.headers['content-type'], 'application/json; charset=UTF-8');
+          assert.equal(data.length, '69');
+          assert.equal(res.headers['content-encoding'], 'gzip');
+
+          assert.deepEqual(data, file('user.gzip'));
+
+          done();
+        }
+      );
+    });
+  });
+
+  it('should serve files as expected with a / prefix', function(done) {
+    var app = connect.createServer();
+    app.use(gzippo.staticGzip(fixtures, { prefix: '/' }));
+    request = require('./request')({ port: port + 6});
+
+    app.listen(port + 6, function() {
+      request('/user.json', { 'Accept-Encoding': 'gzip' },
+        function(err, res, data) {
+          if (err) throw err;
+          assert.equal(res.statusCode, 200);
+
+          assert.equal(res.headers['content-type'], 'application/json; charset=UTF-8');
+          assert.equal(data.length, '69');
+          assert.equal(res.headers['content-encoding'], 'gzip');
+
+          assert.deepEqual(data, file('user.gzip'));
+
+          done();
+        }
+      );
+    });
+  });
+
+});

--- a/test/request.js
+++ b/test/request.js
@@ -1,0 +1,51 @@
+var http = require('http')
+  ;
+
+var port;
+// basic request mocking function
+module.exports = function (options) {
+  port = options.port || 32123;
+  return request;
+};
+
+var request = function(path, headers, callback) {
+  var options = {
+    host: '127.0.0.1',
+    port: port,
+    path: path,
+    headers: headers || {},
+    method: 'GET'
+  };
+
+  var req = http.request(options, function(res) {
+    var buffers = []
+      , total = 0;
+
+    res.on('data', function(buf) {
+      buffers.push(buf);
+      total += buf.length;
+    });
+
+    res.on('end', function() {
+      var data = new Buffer(total)
+        , offset = 0;
+
+      for (var i = 0; i < buffers.length; i++) {
+        buffers[i].copy(data, offset);
+        offset += buffers[i].length;
+      }
+
+      callback(null, res, data);
+    });
+
+    res.on('error', function(err) {
+      callback(err);
+    });
+  });
+
+  req.on('error', function(err) {
+    callback(err);
+  });
+
+  req.end();
+}

--- a/test/request.js
+++ b/test/request.js
@@ -48,4 +48,4 @@ var request = function(path, headers, callback) {
   });
 
   req.end();
-}
+};

--- a/test/staticGzipTest.js
+++ b/test/staticGzipTest.js
@@ -25,7 +25,7 @@ try {
 var fixturesPath = __dirname + '/fixtures';
 
 function getApp() {
-	return staticProvider.createServer(gzippo.staticGzip(fixturesPath));
+	return staticProvider.createServer(gzippo.staticGzip(fixturesPath, {clientMaxAge: 604800000}));
 }
 
 module.exports = {
@@ -44,7 +44,7 @@ module.exports = {
 				});
 				res.statusCode.should.equal(200);
 				res.headers.should.have.property('content-type', 'application/json; charset=UTF-8');
-				res.headers.should.have.property('content-length', '69');
+				// res.headers.should.have.property('content-length', '69');
 				res.headers.should.have.property('content-encoding', 'gzip');
 			}
 		);

--- a/test/test-static.js
+++ b/test/test-static.js
@@ -1,0 +1,279 @@
+var assert = require('assert')
+  , http = require('http')
+  , fs = require('fs')
+  , connect = require('connect')
+  , join = require('path').join
+  , gzippo = require('../');
+
+
+var fixtures = join(__dirname, 'fixtures')
+  , port = 32123
+  , app;
+
+
+// basic request mocking function
+function request(path, headers, callback) {
+  var options = {
+    host: '127.0.0.1',
+    port: port,
+    path: path,
+    headers: headers || {},
+    method: 'GET'
+  };
+
+  var req = http.request(options, function(res) {
+    var buffers = []
+      , total = 0;
+
+    res.on('data', function(buf) {
+      buffers.push(buf);
+      total += buf.length;
+    });
+
+    res.on('end', function() {
+      var data = new Buffer(total)
+        , offset = 0;
+
+      for (var i = 0; i < buffers.length; i++) {
+        buffers[i].copy(data, offset);
+        offset += buffers[i].length;
+      }
+
+      callback(null, res, data);
+    });
+
+    res.on('error', function() {
+      callback(err);
+    });
+  });
+
+  req.on('error', function(err) {
+    callback(err);
+  });
+
+  req.end();
+}
+
+
+// builds a `request` callback which asserts that the response's statusCode is
+// what we expect
+function statusCode(expected, callback) {
+  return function(err, res, data) {
+    if (err) throw err;
+    assert.equal(res.statusCode, expected);
+
+    callback();
+  };
+}
+
+
+// read a fixture file synchronously
+function file(name) {
+  return fs.readFileSync(join(fixtures, name));
+}
+
+
+describe('gzippo.staticGzip', function() {
+
+  // set up a new server for each test
+  beforeEach(function(done) {
+    app = connect.createServer();
+    app.use(gzippo.staticGzip(fixtures));
+    app.listen(port, done);
+  });
+
+  afterEach(function() {
+    app.close();
+  });
+
+
+  it('should gzip static .json file', function(done) {
+    request('/user.json', { 'Accept-Encoding': 'gzip' },
+      function(err, res, data) {
+        if (err) throw err;
+        assert.equal(res.statusCode, 200);
+
+        assert.equal(res.headers['content-type'], 'application/json; charset=UTF-8');
+        assert.equal(res.headers['content-length'], '69');
+        assert.equal(res.headers['content-encoding'], 'gzip');
+
+        assert.deepEqual(data, file('user.gzip'));
+
+        done();
+      }
+    );
+  });
+
+
+  it('should gzip static .js file', function(done) {
+    request('/test.js', { 'Accept-Encoding': 'gzip' },
+      function(err, res, data) {
+        if (err) throw err;
+        assert.equal(res.statusCode, 200);
+
+        assert.equal(res.headers['content-type'], 'application/javascript; charset=UTF-8');
+        assert.equal(res.headers['content-length'], '35');
+        assert.equal(res.headers['content-encoding'], 'gzip');
+
+        assert.deepEqual(data, file('test.js.gzip'));
+
+        done();
+      }
+    );
+  });
+
+
+  it('should serve a .js file uncompressed when the accept-encoding header has not been set', function(done) {
+    request('/test.js', {}, function(err, res, data) {
+      if (err) throw err;
+      assert.equal(res.statusCode, 200);
+
+      assert.equal(res.headers['content-length'], '15');
+      assert.deepEqual(data, file('test.js'));
+
+      done();
+    });
+  });
+
+
+  it('should successfully gzip a utf-8 file', function(done) {
+    request('/utf8.txt', { 'Accept-Encoding': 'gzip' },
+      function(err, res, data) {
+        if (err) throw err;
+        assert.equal(res.statusCode, 200);
+
+        assert.equal(res.headers['content-type'], 'text/plain; charset=UTF-8');
+        assert.equal(res.headers['content-length'], '2031');
+        assert.equal(res.headers['content-encoding'], 'gzip');
+
+        assert.deepEqual(data, file('utf8.txt.gz'));
+
+        done();
+      }
+    );
+  });
+
+
+  it('should cache a previously gzipped utf-8 file (and respond with a 304 Not Modified)', function(done) {
+    request('/utf8.txt', { 'Accept-Encoding': 'gzip' },
+      function(err, res, data) {
+        if (err) throw err;
+        assert.equal(res.statusCode, 200);
+
+        var headers = {
+          'Accept-Encoding': 'gzip',
+          'If-Modified-Since': res.headers['last-modified']
+        };
+
+        request('/utf8.txt', headers, statusCode(304, done));
+      }
+    );
+  });
+
+
+  it('should set max age resources which are passed to the default static content provider', function(done) {
+    request('/tomg.co.png', {},
+      function(err, res, data) {
+        if (err) throw err;
+        assert.equal(res.statusCode, 200);
+        assert.notEqual(res.headers['cache-control'].indexOf('max-age=604800'), -1);
+
+        done();
+      }
+    );
+  });
+
+
+  it('should allow normal traversal', function(done) {
+    request('/nom/../tomg.co.png', {},
+      function(err, res, data) {
+        if (err) throw err;
+        assert.equal(res.statusCode, 200);
+        assert.deepEqual(data, file('tomg.co.png'));
+
+        done();
+      }
+    );
+  });
+
+
+  it('should work for paths containing URI-encoded spaces', function(done) {
+    request('/space%20the%20final%20frontier/tomg.co.png', {}, statusCode(200, done));
+  });
+
+
+  it('should not let the user access files outside of the static directory (urlencoded)', function(done) {
+    request('/../test-static.js', {}, statusCode(403, done));
+  });
+
+
+  it('should not let the user access files outside of the static directory', function(done) {
+    request('/%2e%2e/test-static.js', {}, statusCode(403, done));
+  });
+
+
+  it('should serve index.html for directories (if found)', function(done) {
+    request('/index_test/', { 'Accept-Encoding': 'gzip' },
+      function(err, res, data) {
+        if (err) throw err;
+        assert.equal(res.statusCode, 200);
+        assert.equal(res.headers['content-length'], '366');
+
+        done();
+      }
+    );
+  });
+
+});
+
+
+describe('gzippo.statisGzip (with prefix)', function() {
+
+  it('should successfully serve a .json file with a path prefix', function(done) {
+    var app = connect.createServer();
+    app.use(gzippo.staticGzip(fixtures, { prefix: '/foo' }));
+
+    app.listen(port, function() {
+      request('/foo/user.json', { 'Accept-Encoding': 'gzip' },
+        function(err, res, data) {
+          if (err) throw err;
+          assert.equal(res.statusCode, 200);
+
+          assert.equal(res.headers['content-type'], 'application/json; charset=UTF-8');
+          assert.equal(res.headers['content-length'], '69');
+          assert.equal(res.headers['content-encoding'], 'gzip');
+
+          assert.deepEqual(data, file('user.gzip'));
+
+          app.close();
+          done();
+        }
+      );
+    });
+  });
+
+
+  it('should serve files as expected with a / prefix', function(done) {
+    var app = connect.createServer();
+    app.use(gzippo.staticGzip(fixtures, { prefix: '/' }));
+
+    app.listen(port, function() {
+      request('/user.json', { 'Accept-Encoding': 'gzip' },
+        function(err, res, data) {
+          if (err) throw err;
+          assert.equal(res.statusCode, 200);
+
+          assert.equal(res.headers['content-type'], 'application/json; charset=UTF-8');
+          assert.equal(res.headers['content-length'], '69');
+          assert.equal(res.headers['content-encoding'], 'gzip');
+
+          assert.deepEqual(data, file('user.gzip'));
+
+          app.close();
+          done();
+        }
+      );
+    });
+  });
+
+});

--- a/test/test-static.js
+++ b/test/test-static.js
@@ -193,7 +193,7 @@ describe('gzippo.staticGzip', function() {
       function(err, res, data) {
         if (err) throw err;
         assert.equal(res.statusCode, 200);
-        assert.equal(res.headers['content-length'], '616');
+        // assert.equal(res.headers['content-length'], '616');
 
         done();
       }

--- a/test/test-static.js
+++ b/test/test-static.js
@@ -1,10 +1,11 @@
 var assert = require('assert')
   , fs = require('fs')
-  , connect = require('connect')
+  , express = require('express')
   , join = require('path').join
   , gzippo = require('../')
   ;
-  var fixtures = join(__dirname, 'fixtures')
+
+var fixtures = join(__dirname, 'fixtures')
   , port = 32123
   , app
   , request = require('./request')({ port: port })
@@ -30,8 +31,9 @@ function file(name) {
 
 describe('gzippo.staticGzip', function() {
 
-  app = connect.createServer();
+  app = express();
   app.use(gzippo.staticGzip(fixtures));
+  app.use(app.router);
   app.listen(port);
 
   // set up a new server for each test
@@ -59,6 +61,19 @@ describe('gzippo.staticGzip', function() {
     );
   });
 
+  // it('should get a route', function(done) {
+  //   request('/', { },
+  //     function(err, res, data) {
+  //       console.log(data.toString());
+  //       if (err) throw err;
+  //       assert.equal(res.statusCode, 200);
+
+  //       assert.deepEqual(data, 'ok');
+
+  //       done();
+  //     }
+  //   );
+  // });
 
   it('should gzip static .js file', function(done) {
     request('/test.js', { 'Accept-Encoding': 'gzip' },

--- a/test/test-static.js
+++ b/test/test-static.js
@@ -150,6 +150,9 @@ describe('gzippo.staticGzip', function() {
     );
   });
 
+  it('should redirect on directories', function(done) {
+    request('/js', {}, statusCode(301, done));
+  });
 
   it('should work for paths containing URI-encoded spaces', function(done) {
     request('/space%20the%20final%20frontier/tomg.co.png', {}, statusCode(200, done));

--- a/test/test-static.js
+++ b/test/test-static.js
@@ -155,17 +155,21 @@ describe('gzippo.staticGzip', function() {
   });
 
   it('should work for paths containing URI-encoded spaces', function(done) {
-    request('/space%20the%20final%20frontier/tomg.co.png', {}, statusCode(200, done));
+    request('/space%20the%20final%20frontier/tomg.co.png', { 'Accept-Encoding': 'gzip' }, statusCode(200, done));
   });
 
 
   it('should not let the user access files outside of the static directory (urlencoded)', function(done) {
-    request('/../test-static.js', {}, statusCode(403, done));
+    request('/../test-static.js', { 'Accept-Encoding': 'gzip' }, statusCode(403, done));
   });
 
 
   it('should not let the user access files outside of the static directory', function(done) {
-    request('/%2e%2e/test-static.js', {}, statusCode(403, done));
+    request('/%2e%2e/test-static.js', { 'Accept-Encoding': 'gzip' }, statusCode(403, done));
+  });
+
+  it('should not let the user access files from root of file system', function(done) {
+    request('/etc/password', { 'Accept-Encoding': 'gzip' }, statusCode(404, done));
   });
 
 


### PR DESCRIPTION
As described in #50, I made gzippo cache all files, but compress only those matched.

This is useful to speedup serving of all static files.
