### PR TITLE
Fixes for meteor (particularly on Windows)

### DIFF
--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -174,11 +174,11 @@ exports = module.exports = function staticGzip(dirPath, options){
 
 		fs.stat(decodeURI(filename), function(err, stat) {
 			if (err) {
-				return pass(filename);
+				return next();
 			}
 
 			if (stat.isDirectory()) {
-				return pass(req.url);
+				return next();
 			}
 
 			if (!contentTypeMatch.test(contentType)) {

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -90,8 +90,11 @@ exports = module.exports = function staticGzip(dirPath, options){
 	var
 		maxAge = options.maxAge || 86400000,
 		contentTypeMatch = options.contentTypeMatch || /text|javascript|json/,
-		clientMaxAge = options.clientMaxAge || 604800000,
+		clientMaxAge = options.clientMaxAge,
 		prefix = options.prefix || '';
+
+	if (typeof clientMaxAge === "undefined" || clientMaxAge === null)
+		clientMaxAge = 604800000;
 
 	if (!dirPath) throw new Error('You need to provide the directory to your static content.');
 	if (!contentTypeMatch.test) throw new Error('contentTypeMatch: must be a regular expression.');

--- a/lib/staticGzip.js
+++ b/lib/staticGzip.js
@@ -103,8 +103,9 @@ exports = module.exports = function staticGzip(dirPath, options){
 
 		function pass(name) {
 			var o = Object.create(options);
-			o.path = name;
+			o.path = url.substring(prefix.length);
 			o.maxAge = clientMaxAge;
+			o.root = dirPath;
 			staticSend(req, res, next, o);
 		}
 
@@ -148,14 +149,14 @@ exports = module.exports = function staticGzip(dirPath, options){
 			return next();
 		}
 
-		url = parse(req.url);
+		url = decodeURI(parse(req.url).pathname);
 
 		// Allow a url path prefix
-		if (url.pathname.substring(0, prefix.length) !== prefix) {
+		if (url.substring(0, prefix.length) !== prefix) {
 			return next();
 		}
 
-    filename = path.normalize(path.join(dirPath, url.pathname.substring(prefix.length)));
+    filename = path.normalize(path.join(dirPath, url.substring(prefix.length)));
     // malicious path
     if (0 != filename.indexOf(dirPath)){
       return forbidden(res);
@@ -172,7 +173,7 @@ exports = module.exports = function staticGzip(dirPath, options){
 		//This is storing in memory for the moment, need to think what the best way to do this.
 		//Check file is not a directory
 
-		fs.stat(decodeURI(filename), function(err, stat) {
+		fs.stat(filename, function(err, stat) {
 			if (err) {
 				return next();
 			}

--- a/test/staticGzipTest.js
+++ b/test/staticGzipTest.js
@@ -171,6 +171,16 @@ module.exports = {
 			}
 		);
 	},
+  'max age can be set to 0 to disable caching by the browser': function() {
+		assert.response(staticProvider.createServer(gzippo.staticGzip(fixturesPath, {clientMaxAge: 0})),
+			{
+				url: '/tomg.co.png'
+			},
+			function(res) {
+				assert.includes(res.headers['cache-control'], 'max-age=0');
+			}
+		);
+	},
 	'Normal traversal should work': function() {
 		assert.response(getApp(),
 			{


### PR DESCRIPTION
These changes back port some of the changes from the gzippo devel branch.
They are needed to properly pass the root directory and URL suffix to static.send() rather than passing on file names that kind of look like URLs.

The key reason I need these changes is because I am maintaining a Meteor port for Windows, and on Windows things are much more broken because file names have drive letters and backslashes and static.send() never sends the content.
